### PR TITLE
Fix catalog page not redirecting properly.

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,1 +1,2 @@
 export const APIURL = "http://localhost:5000";
+export const CLIENTURL = "http://localhost:3000";

--- a/client/src/pages/catalog.js
+++ b/client/src/pages/catalog.js
@@ -2,7 +2,7 @@ import React, {useState, useEffect} from "react";
 import { CatalogPage, Search, Tags, Results, Element, Link, Img, NumResults } from "./../components/catalogElements";
 import SearchBar from './../components/SearchBar';
 
-import {APIURL} from '../config.js';
+import {APIURL, CLIENTURL} from '../config.js';
 
 const Catalog = () => {
     const [query, setQuery] = useState([]);
@@ -60,7 +60,7 @@ const Catalog = () => {
 const renderElements = () => {
      let content = [];
      let num = results.length;
-     let link = `${APIURL}/product/`;
+     let link = `${CLIENTURL}/product/`;
      if (num === undefined) {
          content.push(
              <Element>


### PR DESCRIPTION
Please be more careful when changing API routes. @theoneGUI changed a local client URL to a server one, breaking the functionality of the catalog page. This PR fixes that. I'm sure there's a better way to handle redirects but I do not have the time to investigate that currently.