### PR TITLE
Updated default smallnavbar

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -138,14 +138,8 @@ export const SmallerDefaultNavBar = () => {
                 <SmallNavLink to="/login" activeStyle>
                     Login
                 </SmallNavLink>
-                <SmallNavLink to="/dummyPages/myfavorites" activeStyle>
-                    My Favorites
-                </SmallNavLink>
                 <SmallNavLink to="/location-editor" activeStyle>
                     Location Editor
-                </SmallNavLink>
-                <SmallNavLink to="/message-inbox" activeStyle>
-                    Message Inbox
                 </SmallNavLink>
             </SmallNavMenu>
         </smallNav>


### PR DESCRIPTION
We had previously made this change in one of our pull requests, but it must've reverted.